### PR TITLE
V0.51b

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,3 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/opentelemetry-api-feedstock/pr5/e751223
-  - https://staging.continuum.io/prefect/fs/opentelemetry-semantic-conventions-feedstock/pr6/c27cf44
-  
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
 

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,7 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/opentelemetry-api-feedstock/pr5/e751223
+  - https://staging.continuum.io/prefect/fs/opentelemetry-semantic-conventions-feedstock/pr6/c27cf44
+  
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-instrumentation" %}
-{% set version = "0.48b0" %}
+{% set version = "0.51b0" %}
 
 # Common to all opentelemetry python libraries
 {% set vsegments = version.split('.') %}
@@ -30,7 +30,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_instrumentation-{{ version }}.tar.gz
-  sha256: 94929685d906380743a71c3970f76b5f07476eea1834abd5dd9d17abfe23cc35
+  sha256: 4ca266875e02f3988536982467f7ef8c32a38b8895490ddce9ad9604649424fa
 
 build:
   number: 0
@@ -51,6 +51,8 @@ requirements:
     - python
     - opentelemetry-api ~=1.4
     - wrapt <2.0.0,>=1.0.0
+    - opentelemetry-semantic-conventions 0.51b0
+    - packaging >=18.0
 
 test:
   imports:


### PR DESCRIPTION
opentelemetry-instrumentation 0.51b

**Destination channel:**  defaults

### Links

- [PKG-7677](https://anaconda.atlassian.net/browse/PKG-7677) 
- [Upstream repository](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/v0.51b0/opentelemetry-instrumentation)

### Explanation of changes:

- Bump version and SHA
- Build for 3.13
- Update pinnings


[PKG-7677]: https://anaconda.atlassian.net/browse/PKG-7677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ